### PR TITLE
Added LRU cache to tokenize call

### DIFF
--- a/src/bpe_knockout/knockout/core.py
+++ b/src/bpe_knockout/knockout/core.py
@@ -16,7 +16,7 @@ TODO:
 """
 import dataclasses
 from enum import Enum
-from functools import cache
+from functools import cache, lru_cache
 from typing import List, Dict, Callable, Tuple, Set, Iterable
 import json
 import time
@@ -407,7 +407,7 @@ class BTE(TokeniserWithVocab):
             self.merge_graph.addArc(merge_string)
         self.syncWithGraph()
 
-    @cache
+    @lru_cache(maxsize=1024*1024)
     def tokenise(self, pretoken: str) -> List[str]:
         """
         BPE requires two special kinds of pretokenisation that aren't really pretokenisation, before tokenising.


### PR DESCRIPTION
Because of some performance issues (20% gpu usage vs 100% for the original tokenizers), I added a cache to the tokenize call. Since this call should be a pure function, a cache should work.

Some timing experiments:
- No cache: 1.8 sec/iteration
- Cache:    1.6 iterations/sec (0.6 sec/iteration)

On an A100 GPU with 18 threads, this leads to a 2-3.5x speedup (brown line and gray line with different cache sizes).
<img width="561" alt="image" src="https://github.com/bauwenst/BPE-knockout/assets/6965756/96c9cd46-f561-46b1-8292-89dcc1790514">
