### PR TITLE
Improve merge rewire logic to handle multiple instances of type_to_delete in affected merges

### DIFF
--- a/src/bpe_knockout/knockout/core.py
+++ b/src/bpe_knockout/knockout/core.py
@@ -177,12 +177,30 @@ class MergeGraph:
 
         # Rewire all the affected merges.
         for m in list(affected_merges):  # list() because the whole point of this loop is to shrink the list.
+            # CHANGE
+            # making loop for instances when the type_to_delete appears
+            # more than once in the merge.
+            # old version:
+            #   type_to_delete = "zama"
+            #   replacement_parts = ["za", "ma"]
+            #   m = Merge(1, ["zama", "zama"]
+            #   runs self.rewire("zamazama", "za ma zama") # leaves "zama" in the graph
+
+            # new version:
+            #   type_to_delete = "zama"
+            #   replacement_parts = ["za", "ma"]
+            #   m = Merge(1, ["zama", "zama"])
+            #   runs self.rewire("zamazama", "za ma za ma") # removes "zama" from the graph
+            changed_parts = " " + " ".join(m.parts) + " "
+            search = " " + type_to_delete + " "
+            replacement = " " + " ".join(replacement_parts) + " "
+            while search in changed_parts:
+                # Replace the type to delete with its parts.
+                changed_parts = changed_parts.replace(search, replacement)
+
             self.rewire(
-                m.childType(),
-                        (" " + " ".join(m.parts)           + " ")
-                .replace(" " + type_to_delete              + " ",
-                         " " + " ".join(replacement_parts) + " ")
-                .strip()
+                type_to_rewire=m.childType(),
+                new_merge=changed_parts.strip()
             )
 
         # Cut the type out of the graph.


### PR DESCRIPTION
Fix: Rewire Merges to Handle Multiple Occurrences of `type_to_delete`

This pull request modifies the `knockout` function in `core.py` to correctly handle cases where the `type_to_delete` appears multiple times within a merge.

Previously, the `rewire` function would only replace the first instance of `type_to_delete`, leaving subsequent occurrences untouched. This could lead to incorrect merge rewrites and residual instances of the deleted type in the graph.

The updated implementation uses a `while` loop to iteratively replace all instances of `type_to_delete` with `replacement_parts` within the affected merge. This ensures that all occurrences are correctly rewired, effectively removing the `type_to_delete` from the graph.

Example:

-   `type_to_delete` = "zama"
-   `replacement_parts` = \["za", "ma"]
-   `m` = Merge(1, \["zama", "zama"])

Old version:

-   `self.rewire("zamazama", "za ma zama")` # leaves "zama" in the graph

New version:

-   `self.rewire("zamazama", "za ma za ma")` # removes "zama" from the graph